### PR TITLE
Jetpack Onboarding Endpoints

### DIFF
--- a/class.jetpack-onboarding-end-points.php
+++ b/class.jetpack-onboarding-end-points.php
@@ -684,8 +684,10 @@ Warwick, RI 02889
 				}
 			}
 
-			$jp_landing_page = new Jetpack_Landing_Page();
-			$jp_landing_page->add_actions();
+			if ( class_exists( 'Jetpack_Landing_Page' ) ) {
+				$jp_landing_page = new Jetpack_Landing_Page();
+				$jp_landing_page->add_actions();
+			}
 
 			// redirect to activate link
 			$connect_url = Jetpack::init()->build_connect_url( true, admin_url('index.php#welcome/steps/'.$return_to_step) );


### PR DESCRIPTION
Check for `Jetpack_Landing_Page` class before initializing.

The newest version of Jetpack removes `Jetpack_Landing_Page` entirely,
so our endpoint needs to check for it so that it can work in all versions.

Fixes #32 

To test:
- checkout this branch, and `gulp`
- reset your onboarding options
- go through the steps and verify there are no errors

cc: @jessefriedman 