### PR TITLE
Fix Jetpack settings link

### DIFF
--- a/class.jetpack-onboarding-end-points.php
+++ b/class.jetpack-onboarding-end-points.php
@@ -128,7 +128,7 @@ class Jetpack_Onboarding_EndPoints {
 				'contact_page' => $contact_page_info,
 				'business_address' => ( bool ) $business_address_saved,
 				'advanced_settings' => array(
-					'jetpack_modules_url' => admin_url( 'admin.php?page=jetpack_modules' ),
+					'jetpack_modules_url' => admin_url( 'admin.php?page=jetpack#/settings' ),
 					'jetpack_dash' => admin_url( 'admin.php?page=jetpack' ),
 					'widgets_url' => admin_url( 'widgets.php' ),
 					'themes_url' => admin_url( 'themes.php' ),


### PR DESCRIPTION
Update the "Check out the settings page…" link on the Jetpack step to the correct settings page URL.

Fixes #24 (sort of -- that issue was fixed, then Jetpack React happened and the URL is slightly different now)

(Depends on #44)