### PR TITLE
Fix an “undefined variable” error in the WooCommerce step

### DIFF
--- a/client/components/steps/woocommerce.jsx
+++ b/client/components/steps/woocommerce.jsx
@@ -4,7 +4,7 @@ var React = require( 'react' ),
 	SetupProgressActions = require( 'actions/setup-progress-actions' ),
 	WelcomeSection = require( '../page/container' ),
 	SiteActions = require( 'actions/site-actions' ),
-	Paths = require('constants/jetpack-onboarding-paths'),
+	Paths = require( 'constants/jetpack-onboarding-paths' ),
 	Button = require( '@automattic/dops-components/client/components/button' );
 
 function getJetpackState() {
@@ -41,14 +41,14 @@ module.exports = React.createClass( {
 	},
 
 	goToWooSetup: function() {
-		jQuery(window).off('beforeunload');
+		jQuery( window ).off( 'beforeunload' );
 		SiteActions.redirectToWooCommerceSetup();
 		SetupProgressActions.completeStep( Paths.WOOCOMMERCE_SLUG );
 		window.location = this.state.wooCommerceSetupUrl;
 	},
 
 	goToJpoReview: function() {
-		SetupProgressActions.setCurrentStep( Path.REVIEW_STEP_SLUG );
+		SetupProgressActions.setCurrentStep( Paths.REVIEW_STEP_SLUG );
 	},
 
 	handleSubmit: function( event ) {
@@ -84,13 +84,12 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-
 		return (
 			<WelcomeSection id="welcome__jetpack">
 				<h1>Let&apos;s launch <em>{this.state.site_title}</em></h1>
-				{ this.state.wooCommerceStatus
-					? this.renderAlreadyInstalled()
-					: this.renderInstall()
+				{ this.state.wooCommerceStatus ?
+					this.renderAlreadyInstalled() :
+					this.renderInstall()
 				}
 			</WelcomeSection>
 		);

--- a/dist/jetpack-onboarding.js
+++ b/dist/jetpack-onboarding.js
@@ -5438,7 +5438,7 @@ webpackJsonp([1],[
 		},
 
 		goToJpoReview: function goToJpoReview() {
-			SetupProgressActions.setCurrentStep(Path.REVIEW_STEP_SLUG);
+			SetupProgressActions.setCurrentStep(Paths.REVIEW_STEP_SLUG);
 		},
 
 		handleSubmit: function handleSubmit(event) {
@@ -5499,7 +5499,6 @@ webpackJsonp([1],[
 		},
 
 		render: function render() {
-
 			return React.createElement(
 				WelcomeSection,
 				{ id: 'welcome__jetpack' },


### PR DESCRIPTION
There's a typo in the "Not right now" action, `goToJpoReview` -- Path should be Paths. Currently clicking the button gives a `Uncaught ReferenceError: Path is not defined` error.

To test:

- Get to the WooCommerce step with WC already installed/active
- Click "Not right now" for setup
- Should take you to the review step