### PR TITLE
Add production build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.1.0",
   "scripts": {
     "build-css": "gulp",
-    "build-react": "NODE_ENV=production webpack",
+    "build-react": "webpack",
+    "build-react-production": "NODE_ENV=production webpack -p",
     "build": "npm run build-css && npm run build-react",
+    "build-production": "npm run build-css && npm run build-react-production",
     "dev": "webpack",
     "watch": "webpack --watch",
     "lint": "eslint client --ext=js,jsx"


### PR DESCRIPTION
While testing Jetpack Onboarding today, I noticed a warning that we weren't using the production build of React. To address this, I've modified the build commands so that we have a command to do a production build.