### PR TITLE
Remove jpo_reset=1 in favor of CLI command

### DIFF
--- a/class.jetpack-onboarding-end-points.php
+++ b/class.jetpack-onboarding-end-points.php
@@ -261,9 +261,7 @@ class Jetpack_Onboarding_EndPoints {
 	static function reset_data() {
 		check_ajax_referer( self::AJAX_NONCE, 'nonce' );
 
-		delete_option( self::STEP_STATUS_KEY );
-		delete_option( self::STARTED_KEY );
-		delete_option( self::CONTACTPAGE_ID_KEY );
+		jpo_reset();
 
 		wp_send_json_success( 'deleted' );
 	}
@@ -406,21 +404,6 @@ class Jetpack_Onboarding_EndPoints {
 
 		// hide for all users
 		update_option( self::HIDE_FOR_ALL_USERS_OPTION, 1 );
-	}
-
-	static function show_dashboard_widget() {
-		delete_option( self::HIDE_FOR_ALL_USERS_OPTION );
-
-		$setting = get_user_option( get_current_user_id(), "metaboxhidden_dashboard" );
-
-		if ( ! $setting || ! is_array( $setting ) ) {
-			$setting = array();
-		}
-
-		if ( in_array( Jetpack_Onboarding_WelcomePanel::DASHBOARD_WIDGET_ID, $setting ) ) {
-			$setting = array_diff( $setting, array( Jetpack_Onboarding_WelcomePanel::DASHBOARD_WIDGET_ID ) );
-			update_user_option( get_current_user_id(), "metaboxhidden_dashboard", $setting, true );
-		}
 	}
 
 	static function step_view() {

--- a/class.jetpack-onboarding-welcome-panel.php
+++ b/class.jetpack-onboarding-welcome-panel.php
@@ -27,8 +27,6 @@ class Jetpack_Onboarding_WelcomePanel {
 	}
 
 	static function add_dashboard_widgets() {
-		self::reset_data_if_necessary();
-
 		if ( get_option( Jetpack_Onboarding_EndPoints::HIDE_FOR_ALL_USERS_OPTION ) ) {
 			return;
 		}
@@ -65,38 +63,6 @@ class Jetpack_Onboarding_WelcomePanel {
 		wp_enqueue_style( 'jetpack-onboarding-components', plugins_url( 'dist/jetpack-onboarding.css', __FILE__ ), array( 'wp-admin' ) );
 		wp_enqueue_style( 'jetpack-onboarding-panel', plugins_url( 'css/welcome-panel.css', __FILE__ ), array( 'wp-admin', 'wp-pointer', 'dashicons' ) );
 		wp_enqueue_style( 'ie8' );
-	}
-
-	static function reset_data_if_necessary() {
-		//reset data
-		if ( isset( $_GET['jpo_reset'] ) ) {
-			delete_option( Jetpack_Onboarding_EndPoints::STEP_STATUS_KEY );
-			delete_option( Jetpack_Onboarding_EndPoints::FIRSTRUN_KEY );
-			delete_option( Jetpack_Onboarding_EndPoints::STARTED_KEY );
-			Jetpack_Onboarding_EndPoints::show_dashboard_widget();
-			delete_option( Jetpack_Onboarding_EndPoints::CONTACTPAGE_ID_KEY );
-			delete_option( Jetpack_Onboarding_EndPoints::HIDE_FOR_ALL_USERS_OPTION );
-
-			delete_option( 'jetpack_blog_token' );
-			delete_option( 'jetpack_id' );
-
-			//also reset JP data
-			delete_option( 'jetpack_options'        );
-
-			// Delete all non-compact options
-			delete_option( 'jetpack_register'       );
-			delete_option( 'jetpack_activated'      );
-			delete_option( 'jetpack_active_modules' );
-			delete_option( 'jetpack_do_activate'    );
-
-			// Delete all legacy options
-			delete_option( 'jetpack_was_activated'  );
-			delete_option( 'jetpack_auto_installed' );
-			delete_transient( 'jetpack_register'    );
-
-			wp_redirect(remove_query_arg('jpo_reset'));
-			die();
-		}
 	}
 
 	static function render_widget() {

--- a/jetpack-onboarding.php
+++ b/jetpack-onboarding.php
@@ -6,6 +6,9 @@
  * Version: 1.7.1
  */
 
+require_once( plugin_dir_path( __FILE__ ) . 'class.jetpack-onboarding-end-points.php' );
+require_once( plugin_dir_path( __FILE__ ) . 'class.jetpack-onboarding-welcome-panel.php' );
+
 defined( 'JETPACK_ONBOARDING_BASE_DIR' )         or define( 'JETPACK_ONBOARDING_BASE_DIR', dirname( __FILE__ ) );
 defined( 'JETPACK_ONBOARDING_BASE_URL' )         or define( 'JETPACK_ONBOARDING_BASE_URL', plugin_dir_url( __FILE__ ) );
 defined( 'JETPACK_STEP_AUTO_REDIRECT' )     or define( 'JETPACK_STEP_AUTO_REDIRECT', true );
@@ -13,14 +16,51 @@ defined( 'JETPACK_STEP_AUTO_REDIRECT_SRC' ) or define( 'JETPACK_STEP_AUTO_REDIRE
 defined( 'JETPACK_ONBOARDING_VENDOR_CODE' ) or define( 'JETPACK_ONBOARDING_VENDOR_CODE', 'unknown' );
 defined( 'JETPACK_ONBOARDING_PRODUCT_CODE' ) or define( 'JETPACK_ONBOARDING_PRODUCT_CODE', 'unknown' );
 
+register_uninstall_hook( __FILE__, 'jpo_reset' );
+
 function jpo_start() {
 	if ( is_admin() && current_user_can( 'administrator' ) ) {
-		require_once( plugin_dir_path( __FILE__ ) . 'class.jetpack-onboarding-end-points.php' );
-		require_once( plugin_dir_path( __FILE__ ) . 'class.jetpack-onboarding-welcome-panel.php' );
-
 		Jetpack_Onboarding_EndPoints::init();
 		Jetpack_Onboarding_WelcomePanel::init();
 	}
 }
-
 add_action( 'init',  'jpo_start' );
+
+function jpo_reset() {
+	delete_option( Jetpack_Onboarding_EndPoints::STEP_STATUS_KEY );
+	delete_option( Jetpack_Onboarding_EndPoints::FIRSTRUN_KEY );
+	delete_option( Jetpack_Onboarding_EndPoints::STARTED_KEY );
+	delete_option( Jetpack_Onboarding_EndPoints::CONTACTPAGE_ID_KEY );
+	delete_option( Jetpack_Onboarding_EndPoints::HIDE_FOR_ALL_USERS_OPTION );
+
+	// If we have a current user, reset JPO for only the current user.
+	// Otherwise, reset for all admins.
+	$users = array();
+	if ( get_current_user_id() ) {
+		$users[] = get_current_user_id();
+	} else {
+		$users_query = get_users( array(
+			'role' => 'administrator',
+			'fields' => array( 'id' ) )
+		);
+
+		$users = wp_list_pluck( $users_query, 'id' );
+	}
+
+	foreach ( $users as $user_id ) {
+		$setting = get_user_option( 'metaboxhidden_dashboard', $user_id );
+
+		if ( ! $setting || ! is_array( $setting ) ) {
+			$setting = array();
+		}
+
+		if ( in_array( Jetpack_Onboarding_WelcomePanel::DASHBOARD_WIDGET_ID, $setting ) ) {
+			$setting = array_diff( $setting, array( Jetpack_Onboarding_WelcomePanel::DASHBOARD_WIDGET_ID ) );
+			update_user_option( $user_id, "metaboxhidden_dashboard", $setting, true );
+		}
+	}
+}
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	WP_CLI::add_command( 'jpo reset', 'jpo_reset' );
+}

--- a/jetpack-onboarding.php
+++ b/jetpack-onboarding.php
@@ -32,6 +32,7 @@ function jpo_reset() {
 	delete_option( Jetpack_Onboarding_EndPoints::STARTED_KEY );
 	delete_option( Jetpack_Onboarding_EndPoints::CONTACTPAGE_ID_KEY );
 	delete_option( Jetpack_Onboarding_EndPoints::HIDE_FOR_ALL_USERS_OPTION );
+	delete_option( Jetpack_Onboarding_EndPoints::SITE_TYPE );
 
 	// If we have a current user, reset JPO for only the current user.
 	// Otherwise, reset for all admins.


### PR DESCRIPTION
This PR removes the prior functionality of using `jpo_reset=1` to reset JPO, and instead, provides a `wp jpo reset` command. Further, this PR removes some duplication so that there's one function that does the reset.

This PR also fixes an issue with resetting the dashboard widget. Previously, the args were passed incorrectly to get the hidden dashboard widgets.

To test:

- Checkout patch
- Go through JPO
- Run `wp jpo reset` in CLI to reset